### PR TITLE
Fix: Resolve ImportError for generate_command_line

### DIFF
--- a/synthemol/generate/__init__.py
+++ b/synthemol/generate/__init__.py
@@ -11,3 +11,4 @@ from synthemol.generate.rl_models import (
 )
 from synthemol.generate.scorer import MoleculeScorer
 from synthemol.generate.utils import save_generated_molecules
+from synthemol.generate.generate import generate_command_line


### PR DESCRIPTION
The `generate_command_line` function was not being exported in `synthemol/generate/__init__.py`, leading to an `ImportError` when you tried to import it from `synthemol.generate` in `scripts/generate.py`.

This commit adds the necessary import to `synthemol/generate/__init__.py` to correctly expose the `generate_command_line` function.